### PR TITLE
Support optional ContentType item metadata in UploadToAzure (#1819)

### DIFF
--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadClient.cs
@@ -46,6 +46,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             string ContainerName,
             string filePath,
             string destinationBlob,
+            string contentType,
             int uploadTimeout,
             string leaseId = "")
         {
@@ -151,7 +152,10 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                     var req = new HttpRequestMessage(HttpMethod.Put, blockListUploadUrl);
                     req.Headers.Add(AzureHelper.DateHeaderString, dt1.ToString("R", CultureInfo.InvariantCulture));
                     req.Headers.Add(AzureHelper.VersionHeaderString, AzureHelper.StorageApiVersion);
-                    string contentType = DetermineContentTypeBasedOnFileExtension(filePath);
+                    if (string.IsNullOrEmpty(contentType))
+                    {
+                        contentType = DetermineContentTypeBasedOnFileExtension(filePath);
+                    }
                     if (!string.IsNullOrEmpty(contentType))
                     {
                         req.Headers.Add(AzureHelper.ContentTypeString, contentType);

--- a/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
+++ b/src/Microsoft.DotNet.Build.CloudTestTasks/UploadToAzure.cs
@@ -140,6 +140,8 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
             if (!Overwrite && blobsPresent.Contains(relativeBlobPath))
                 throw new Exception(string.Format("The blob '{0}' already exists.", relativeBlobPath));
 
+            string contentType = item.GetMetadata("ContentType");
+
             await clientThrottle.WaitAsync();
 
             try
@@ -154,6 +156,7 @@ namespace Microsoft.DotNet.Build.CloudTestTasks
                         ContainerName,
                         item.ItemSpec,
                         relativeBlobPath,
+                        contentType,
                         UploadTimeoutInMinutes);
             }
             finally

--- a/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
+++ b/src/Microsoft.DotNet.Build.Tasks.Feed/BlobFeedAction.cs
@@ -111,6 +111,8 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                 relativeBlobPath = $"{recursiveDir}{fileName}";
             }
 
+            string contentType = item.GetMetadata("ContentType");
+
             relativeBlobPath = $"{feed.RelativePath}{relativeBlobPath}".Replace("\\", "/");
 
             Log.LogMessage($"Uploading {relativeBlobPath}");
@@ -137,6 +139,7 @@ namespace Microsoft.DotNet.Build.Tasks.Feed
                         feed.ContainerName,
                         item.ItemSpec,
                         relativeBlobPath,
+                        contentType,
                         uploadTimeout);
                 }
                 else


### PR DESCRIPTION
Prefer explicit content type specification in the item metadata
and only use autodetection when not available. We're using this
for uploading test logs and results to Azure - without proper
content type some browsers have trouble opening them.